### PR TITLE
Functionality for Releasing Locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # redis-lock
-Redis Based API for acquiring lock on a value for a specified amount of time.
+Redis Based API for acquiring and releasing lock on a value for a specified amount of time.
 
 # Running Locally
 **Prerequisites**
@@ -39,5 +39,29 @@ If you make the second request within the key expiration window, in this case 5 
 {
     "status": 406,
     "message": "12345 is duplicate"
+}
+```
+
+To manually remove the lock, use the following cURL command
+
+```
+curl --location --request GET 'http://127.0.0.1:8000/api/v1/unlock?key=12345'
+```
+
+Upon successfully removing a key from Redis, you will get the following response
+
+```
+{
+    "status": 202,
+    "message": "12345 is removed"
+}
+```
+
+If the key is not present in Redis, you will get the following response
+
+```
+{
+    "status": 404,
+    "message": "12345 didn't exist"
 }
 ```

--- a/src/configs/redis_datasource.py
+++ b/src/configs/redis_datasource.py
@@ -22,3 +22,6 @@ class RedisDatasource:
 
     def set_key(self, key: str, key_expiry: int):
         return self.redis_connection.set(key, 'DUMMY', ex=key_expiry, nx=True)
+
+    def delete_key(self, key: str):
+        return self.redis_connection.delete(key)

--- a/src/controllers/api.py
+++ b/src/controllers/api.py
@@ -14,9 +14,18 @@ api_router = APIRouter(
 
 @api_router.get('/lock')
 @inject
-def sample(
+def lock(
         key: str,
         key_expiry: int,
         redis_service: RedisService = Depends(Provide[Container.redis_service])
 ):
     return redis_service.get_lock(key, key_expiry)
+
+
+@api_router.get('/unlock')
+@inject
+def unlock(
+        key: str,
+        redis_service: RedisService = Depends(Provide[Container.redis_service])
+):
+    return redis_service.remove_lock(key)

--- a/src/services/redis_service.py
+++ b/src/services/redis_service.py
@@ -18,3 +18,12 @@ class RedisService:
 
         logger.info(f'{key} is duplicate')
         return dict(status=406, message=f'{key} is duplicate')
+
+    def remove_lock(self, key: str):
+        redis_response = self.redis_datasource.delete_key(key)
+        if redis_response:
+            logger.info(f'{key} is removed')
+            return dict(status=202, message=f'{key} is removed')
+
+        logger.info(f'{key} didn\'t exist')
+        return dict(status=404, message=f'{key} didn\'t exist')


### PR DESCRIPTION
1. In RedisDatasource, added the method to delete the key from redis
2. RedisService method remove_lock handles the deletion of key based on whether the key already existed or not
3. Exposing a new endpoint /api/v1/unlock to call the remove_lock method of RedisService
4. Updating the README.md file to explain the functionality and testing of releasing a lock